### PR TITLE
fixed Simultaneous accesses error, but modification requires exclusiv…

### DIFF
--- a/Sources/Foundation/NotificationCenter+TSBlock.swift
+++ b/Sources/Foundation/NotificationCenter+TSBlock.swift
@@ -57,9 +57,7 @@ private var TSObservationRemoverKey: UnsafeRawPointer? = nil
 
 private func ts_observationRemoversForObject(_ object: AnyObject) -> NSMutableArray {
     if TSObservationRemoverKey == nil {
-        withUnsafePointer(to: &TSObservationRemoverKey) { pointer in
-            TSObservationRemoverKey = UnsafeRawPointer(pointer)
-        }
+        ObservationRemoverKey = withUnsafeMutablePointer(to: &ObservationRemoverKey) { UnsafeRawPointer($0) }
     }
     
     var retainedRemovers = objc_getAssociatedObject(object, TSObservationRemoverKey!) as! NSMutableArray?


### PR DESCRIPTION
error stack

```
Simultaneous accesses to 0x103582e90, but modification requires exclusive access.
Previous access (a modification) started at TimedSilver`ts_observationRemoversForObject(_:) + 292 (0x103510d84).
Current access (a modification) started at:
0    libswiftCore.dylib                 0x0000000108cc3f00 swift_beginAccess + 505
1    TimedSilver                        0x0000000103511580 closure #1 in ts_observationRemoversForObject(_:) + 54
2    TimedSilver                        0x00000001035115d0 thunk for @callee_owned (@unowned UnsafePointer<UnsafeRawPointer?>) -> (@error @owned Error) + 22
3    TimedSilver                        0x0000000103512e60 partial apply for thunk for @callee_owned (@unowned UnsafePointer<UnsafeRawPointer?>) -> (@error @owned Error) + 91
4    libswiftCore.dylib                 0x0000000108a9f640 withUnsafePointer<A, B>(to:_:) + 12
5    TimedSilver                        0x0000000103510c60 ts_observationRemoversForObject(_:) + 375
6    TimedSilver                        0x0000000103510bf0 TSObservationRemover.makeRetainedBy(_:) + 38
7    TimedSilver                        0x000000010350faa0 NotificationCenter.ts_addObserver<A>(_:name:object:queue:handler:) + 923
8    TSWeChat                           0x000000010240e900 TSChatViewController.keyboardControl() + 406
9    TSWeChat                           0x000000010242ffb0 TSChatViewController.viewDidLoad() + 1877

```